### PR TITLE
Flake8: Undefined name 'display_genre' in catalog/models.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/circleci-demo-python-django
     docker:
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.6.5
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
@@ -19,7 +19,7 @@ jobs:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
-            sudo pip install pipenv
+            sudo pip install flake8 pipenv
             pipenv install
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -29,6 +29,7 @@ jobs:
             - "/usr/local/lib/python3.6/site-packages"
       - run:
           command: |
+            pipenv run "flake8 . --select=E901,E999,F821,F822,F823 --show-source"
             pipenv run "python manage.py test"
       - store_test_results:
           path: test-results


### PR DESCRIPTION
Add [__flake8__](http://flake8.pycqa.org) to the testing...  Fail the build if there are Python syntax errors or undefined names

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./catalog/models.py:54:9: F821 undefined name 'display_genre'
        display_genre.short_description = 'Genre'
        ^
1     F821 undefined name 'display_genre'
1
```