### PR TITLE
Fix test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             - "/usr/local/lib/python3.6/site-packages"
       - run:
           command: |
-            pipenv run "python manage.py test"
+            pipenv run python manage.py test
       - store_test_results:
           path: test-results
       - store_artifacts:


### PR DESCRIPTION
Test command should be `pipenv run python manage.py test` not `pipenv run "python manage.py test"`
Resolves #15 (https://github.com/CircleCI-Public/circleci-demo-python-django/issues/15)
### Before
```shell
pipenv run "python manage.py test"
```

```shell
#!/bin/bash -eo pipefail
pipenv run "python manage.py test"
Error: the command python manage.py test could not be found within PATH or Pipfile's [scripts].
Exited with code 1
```

### After
```shell
pipenv run python manage.py test
```

```shell
#!/bin/bash -eo pipefail
pipenv run python manage.py test
Creating test database for alias 'default'...
```